### PR TITLE
fix: Allow installer ISO to be fetched from different repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   installer-major-version:
     description: 'Major version of the installer to use'
     required: true
+  installer-repo:
+    description: 'Fedora repository to use for the installer'
+    required: false
+    default: 'releases'
   kickstart-file-path:
     description: 'Path to the kickstart file'
     required: true
@@ -25,7 +29,7 @@ runs:
       run: |
         curl -L $EVERYTHING_INSTALLER_URL -o Fedora-Everything-netinst-x86_64.iso
       env:
-        EVERYTHING_INSTALLER_URL: https://download.fedoraproject.org/pub/fedora/linux/releases/${{ inputs.installer-major-version }}/Everything/x86_64/os/images/boot.iso
+        EVERYTHING_INSTALLER_URL: https://download.fedoraproject.org/pub/fedora/linux/${{ inputs.installer-repo }}/${{ inputs.installer-major-version }}/Everything/x86_64/os/images/boot.iso
 
     - name: Build ISO
       shell: bash


### PR DESCRIPTION
We might sometimes want to fetch the ISO from `development`, rather than `releases`.  