### PR TITLE
fix: add magic xorriso args to make hybryd iso

### DIFF
--- a/generate-installer-media.sh
+++ b/generate-installer-media.sh
@@ -41,7 +41,12 @@ for GRUB_CONFIG in ${WORK_DIR}/overlay/{boot/grub2/grub.cfg,EFI/BOOT/{grub.cfg,B
     fi
 done
 
-xorriso -indev "${INPUT_ISO}" -outdev "${ISO_FILE}" -boot_image any replay -map "${WORK_DIR}/overlay" /
+xorriso \
+    -indev "${INPUT_ISO}" \
+    -outdev "${ISO_FILE}" \
+    -boot_image any replay \
+    -boot_image any part_like_isohybrid=on \
+    -map "${WORK_DIR}/overlay" /
 
 implantisomd5 "${ISO_FILE}"
 


### PR DESCRIPTION
The only real addition is `-boot_image any part_like_isohybrid=on` which I took from the [manpage](https://www.gnu.org/software/xorriso/man_1_xorriso_devel.html)

> `-boot_image any part_like_isohybrid=on` enables `-boot_image isolinux partition_entry=` even if no `-boot_image isolinux system_area=` is given. No MBR partition of type 0xee emerges, even if GPT gets produced. Gaps between GPT and APM partitions will not be filled by more partitions. Appended partitions get mentioned in APM if other APM partitions emerge.

to be clear I have no idea what this means but it seems to work. 

I have tested on two VMs with USB passthrough to simulate native USB booting and also with CD-ROM booting.