### PR TITLE
fix: add `tree` as dependency, fix bug in privileged container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,14 @@
+FROM fedora:38
+
+RUN dnf install \
+        --disablerepo='*' \
+        --enablerepo='fedora,updates' \
+        --setopt install_weak_deps=0 \
+        --assumeyes \
+        ansible \
+        curl \
+        isomd5sum \
+        jq \
+        parted \
+        tree \
+        xorriso

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,7 @@ runs:
           isomd5sum \
           jq \
           parted \
+          tree \
           xorriso
         
     - name: Download Fedora Everything Installer

--- a/isopatch.sh
+++ b/isopatch.sh
@@ -87,7 +87,7 @@ get_esp_offset() {
     IMG_FILE="$1"
     parted --json --script "${IMG_FILE}" \
         unit b \
-        print list \
+        print \
         | jq --raw-output '
             .disk.partitions[] 
             | select(.number == 2)
@@ -98,7 +98,7 @@ get_esp_size() {
     IMG_FILE="$1"
     parted --json --script "${IMG_FILE}" \
         unit b \
-        print list \
+        print \
         | jq --raw-output '
             .disk.partitions[] 
             | select(.number == 2)

--- a/util/isopatch.sh
+++ b/util/isopatch.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+exec sudo podman run \
+    --rm \
+    -it \
+    --privileged \
+    --security-opt label=disable \
+    -v "$PWD:$PWD" \
+    -w "$PWD" \
+    isogenerator:builder \
+    "$PWD/isopatch.sh" "$@"


### PR DESCRIPTION
The bug caused all partition tables on the system to be dumped which caused errors when we expected a single number when querying for ESP size