### PR TITLE
chore: add release-please for better GH Actions versioning

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,6 +7,8 @@ on:
       - '**.md'
       - '**.txt'
   push:
+    branches:
+      - main
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -66,7 +68,7 @@ jobs:
           path: ublue-test.iso
 
   release-please:
-    if: ${{ github.ref }} == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs:
       - shellcheck
       - isopatch-test

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -64,3 +64,20 @@ jobs:
         with:
           name: ublue-test.iso
           path: ublue-test.iso
+
+  release-please:
+    if: ${{ github.ref }} == 'refs/heads/main'
+    needs:
+      - shellcheck
+      - isopatch-test
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
+      tag: ${{ steps.release-please.outputs.tag_name }}
+      upload_url: ${{ steps.release-please.outputs.upload_url }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release-please
+        with:
+          release-type: node
+          package-name: release-please-action

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -68,6 +68,9 @@ jobs:
           path: ublue-test.iso
 
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs:
       - shellcheck


### PR DESCRIPTION
this will allow the consumers to specify the version tag eg:

```
uses: ublue-os/isogenerator@v1.0.0
```

which should let us make changes to the action without breaking existing consumers going forward