### PR TITLE
chore: remove hardcoded refs, add action selftest

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -32,40 +32,28 @@ jobs:
       - name: run shellcheck
         run: ./util/shellcheck isopatch.sh
 
-  isopatch-test:
-    name: test isopatch by running it
-    runs-on: ubuntu-22.04
+  selftest:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
     container:
       image: fedora:38
       options: --privileged
     steps:
-      # Checkout push-to-registry action GitHub repository
-      - name: Checkout Push to Registry action
+      - name: checkout to execute local action
         uses: actions/checkout@v3
-
-      - name: install dependencies
-        run: |
-          sudo dnf install \
-            --disablerepo='*' \
-            --enablerepo='fedora,updates' \
-            --setopt install_weak_deps=0 \
-            --assumeyes \
-            $(cat deps.txt)
-
-      - name: fetch net installer to patch
-        run: |
-          curl -L $EVERYTHING_INSTALLER_URL -o Fedora-Everything-netinst-x86_64.iso
-        env:
-          EVERYTHING_INSTALLER_URL: https://mirror.fcix.net/fedora/linux/development/38/Everything/x86_64/os/images/boot.iso
-
-      - name: run isopatch.sh
-        run: |
-          ./isopatch.sh Fedora-Everything-netinst-x86_64.iso ublue-test.iso
-
-      - uses: actions/upload-artifact@v3
+      - name: do selftest of the action
+        uses: ./
+        id: selftest
         with:
+          image-name: ublue-test
+          installer-major-version: 38
+          installer-repo: development
+      - name: upload test result as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ steps.selftest.outputs.iso-path }}
           name: ublue-test.iso
-          path: ublue-test.iso
 
   release-please:
     permissions:
@@ -74,7 +62,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs:
       - shellcheck
-      - isopatch-test
+      - selftest
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -52,8 +52,8 @@ jobs:
       - name: upload test result as artifact
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ steps.selftest.outputs.iso-path }}
-          name: ublue-test.iso
+          path: ${{ steps.selftest.outputs.iso-name }}
+          name: ${{ steps.selftest.outputs.iso-name }}
 
   release-please:
     permissions:

--- a/action.yml
+++ b/action.yml
@@ -82,3 +82,6 @@ outputs:
   iso-path:
     description: 'Path to the generated ISO'
     value: ${{ steps.build.outputs.ISO_FILENAME }}
+  iso-name:
+    description: 'ISO name without path'
+    value: ${{ steps.iso-name.outputs.iso_name }}

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
         
     - name: Download Fedora Everything Installer
       shell: bash
-      working-directory: /__w/_actions/ublue-os/isogenerator/main/
+      working-directory: ${{ github.action_path }}
       run: |
         curl -L $EVERYTHING_INSTALLER_URL -o Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso
       env:
@@ -60,20 +60,20 @@ runs:
     - name: Build ISO
       shell: bash
       id: build
-      working-directory: /__w/_actions/ublue-os/isogenerator/main/
+      working-directory: ${{ github.action_path }}
       run: |
         ./isopatch.sh Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso ${{ steps.iso-name.outputs.iso_name }}
-        echo "ISO_FILENAME=/__w/_actions/ublue-os/isogenerator/main/${{ steps.iso-name.outputs.iso_name }}" >> $GITHUB_OUTPUT
+        echo "ISO_FILENAME=${{ github.action_path }}/${{ steps.iso-name.outputs.iso_name }}" >> $GITHUB_OUTPUT
         
     - name: Calculate SHA256 
       id: calculate
       shell: bash
-      working-directory: /__w/_actions/ublue-os/isogenerator/main/
+      working-directory: ${{ github.action_path }}
       run: |
         echo "# ${{ steps.iso-name.outputs.iso_name }}: $(stat -c '%s' ${{ steps.iso-name.outputs.iso_name }}) bytes" > ${{ steps.iso-name.outputs.iso_name }}.sha256sum
         sha256sum --tag "${{ steps.iso-name.outputs.iso_name }}" >> ${{ steps.iso-name.outputs.iso_name }}.sha256sum
         cat ${{ steps.iso-name.outputs.iso_name }}.sha256sum
-        echo "SHA256SUM_FILENAME=/__w/_actions/ublue-os/isogenerator/main/${{ steps.iso-name.outputs.iso_name }}.sha256sum" >> $GITHUB_OUTPUT
+        echo "SHA256SUM_FILENAME=${{ github.action_path }}/${{ steps.iso-name.outputs.iso_name }}.sha256sum" >> $GITHUB_OUTPUT
 
 outputs:
   sha256sum-path:


### PR DESCRIPTION
1. removed hardcoded refs so consumers can use versioned tags
2. added action selftest - to verify above and in the future help us verify the action works as expected