### PR TITLE
chore: Remove hard-coded ref for fetching dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,13 +41,15 @@ runs:
 
     - name: Install Dependencies
       shell: bash
+      working_directory: ${{ github.action_path }}
       run: |
+        PACKAGES=$(cat deps.txt)
         dnf install \
           --disablerepo='*' \
           --enablerepo='fedora,updates' \
           --setopt install_weak_deps=0 \
           --assumeyes \
-          $(cat ${{ github.action_path }}/deps.txt)
+          $PACKAGES
         
     - name: Download Fedora Everything Installer
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
           --enablerepo='fedora,updates' \
           --setopt install_weak_deps=0 \
           --assumeyes \
-          $(curl -s https://raw.githubusercontent.com/ublue-os/isogenerator/main/deps.txt)
+          $(curl -s https://raw.githubusercontent.com/ublue-os/isogenerator/${{ github.action_ref	}}/deps.txt)
         
     - name: Download Fedora Everything Installer
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
           --enablerepo='fedora,updates' \
           --setopt install_weak_deps=0 \
           --assumeyes \
-          $(curl -s https://raw.githubusercontent.com/ublue-os/isogenerator/${{ github.action_ref }}/deps.txt)
+          $(cat ${{ github.action_path }}/deps.txt)
         
     - name: Download Fedora Everything Installer
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - name: Install Dependencies
       shell: bash
-      working_directory: ${{ github.action_path }}
+      working-directory: ${{ github.action_path }}
       run: |
         PACKAGES=$(cat deps.txt)
         dnf install \

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
           --enablerepo='fedora,updates' \
           --setopt install_weak_deps=0 \
           --assumeyes \
-          $(curl -s https://raw.githubusercontent.com/ublue-os/isogenerator/${{ github.action_ref	}}/deps.txt)
+          $(curl -s https://raw.githubusercontent.com/ublue-os/isogenerator/${{ github.action_ref }}/deps.txt)
         
     - name: Download Fedora Everything Installer
       shell: bash


### PR DESCRIPTION
The final hard-coded ref was used to fetch the dependencies required for this job.
This PR changes the working directory used in the deps step so we can read from `deps.txt` rather than `curl`ing `main`