### PR TITLE
fix: move output to GITHUB_WORKSPACE so consumer action can access it

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,18 +64,18 @@ runs:
       id: build
       working-directory: ${{ github.action_path }}
       run: |
-        ./isopatch.sh Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso ${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}
-        echo "ISO_FILENAME=${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}" >> $GITHUB_OUTPUT
+        ./isopatch.sh Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso ${{ steps.iso-name.outputs.iso_name }}
+        echo "ISO_FILENAME=${{ steps.iso-name.outputs.iso_name }}" >> $GITHUB_OUTPUT
         
     - name: Calculate SHA256 
       id: calculate
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        echo "# ${{ steps.iso-name.outputs.iso_name }}: $(stat -c '%s' ${{ steps.iso-name.outputs.iso_name }}) bytes" > ${{ steps.iso-name.outputs.iso_name }}.sha256sum
-        sha256sum --tag "${{ steps.iso-name.outputs.iso_name }}" >> ${{ steps.iso-name.outputs.iso_name }}.sha256sum
+        echo "# ${{ steps.iso-name.outputs.iso_name }}: $(stat -c '%s' ${{ steps.iso-name.outputs.iso_name }}) bytes" > ${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}.sha256sum
+        sha256sum --tag "${{ steps.iso-name.outputs.iso_name }}" >> ${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}.sha256sum
         cat ${{ steps.iso-name.outputs.iso_name }}.sha256sum
-        echo "SHA256SUM_FILENAME=${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}.sha256sum" >> $GITHUB_OUTPUT
+        echo "SHA256SUM_FILENAME=${{ steps.iso-name.outputs.iso_name }}.sha256sum" >> $GITHUB_OUTPUT
 
 outputs:
   sha256sum-path:

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
       id: build
       working-directory: ${{ github.action_path }}
       run: |
-        ./isopatch.sh Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso ${{ steps.iso-name.outputs.iso_name }}
+        ./isopatch.sh Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso ${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}
         echo "ISO_FILENAME=${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}" >> $GITHUB_OUTPUT
         
     - name: Calculate SHA256 

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         ./isopatch.sh Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso ${{ steps.iso-name.outputs.iso_name }}
-        echo "ISO_FILENAME=$PWD/${{ steps.iso-name.outputs.iso_name }}" >> $GITHUB_OUTPUT
+        echo "ISO_FILENAME=${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}" >> $GITHUB_OUTPUT
         
     - name: Calculate SHA256 
       id: calculate
@@ -75,7 +75,7 @@ runs:
         echo "# ${{ steps.iso-name.outputs.iso_name }}: $(stat -c '%s' ${{ steps.iso-name.outputs.iso_name }}) bytes" > ${{ steps.iso-name.outputs.iso_name }}.sha256sum
         sha256sum --tag "${{ steps.iso-name.outputs.iso_name }}" >> ${{ steps.iso-name.outputs.iso_name }}.sha256sum
         cat ${{ steps.iso-name.outputs.iso_name }}.sha256sum
-        echo "SHA256SUM_FILENAME=$PWD/${{ steps.iso-name.outputs.iso_name }}.sha256sum" >> $GITHUB_OUTPUT
+        echo "SHA256SUM_FILENAME=${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}.sha256sum" >> $GITHUB_OUTPUT
 
 outputs:
   sha256sum-path:

--- a/action.yml
+++ b/action.yml
@@ -72,9 +72,6 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        echo "# ${{ steps.iso-name.outputs.iso_name }}: $(stat -c '%s' ${{ steps.iso-name.outputs.iso_name }}) bytes" > ${{ steps.iso-name.outputs.iso_name }}.sha256sum
-        sha256sum --tag "${{ steps.iso-name.outputs.iso_name }}" >> ${{ steps.iso-name.outputs.iso_name }}.sha256sum
-        cat ${{ steps.iso-name.outputs.iso_name }}.sha256sum
         echo "SHA256SUM_FILENAME=${{ steps.iso-name.outputs.iso_name }}.sha256sum" >> $GITHUB_OUTPUT
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -55,9 +55,9 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        curl -L $EVERYTHING_INSTALLER_URL -o Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso
+        aria2c $EVERYTHING_INSTALLER_URL -o Fedora-Everything-netinst-${{ inputs.cpu-arch }}.iso
       env:
-        EVERYTHING_INSTALLER_URL: https://mirror.fcix.net/fedora/linux/${{ inputs.installer-repo }}/${{ inputs.installer-major-version }}/Everything/${{ inputs.cpu-arch }}/os/images/boot.iso
+        EVERYTHING_INSTALLER_URL: https://mirror.xenyth.net/fedora/linux/${{ inputs.installer-repo }}/${{ inputs.installer-major-version }}/Everything/${{ inputs.cpu-arch }}/os/images/boot.iso
         
     - name: Build ISO
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -72,8 +72,8 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        echo "# ${{ steps.iso-name.outputs.iso_name }}: $(stat -c '%s' ${{ steps.iso-name.outputs.iso_name }}) bytes" > ${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}.sha256sum
-        sha256sum --tag "${{ steps.iso-name.outputs.iso_name }}" >> ${{ github.workspace }}/${{ steps.iso-name.outputs.iso_name }}.sha256sum
+        echo "# ${{ steps.iso-name.outputs.iso_name }}: $(stat -c '%s' ${{ steps.iso-name.outputs.iso_name }}) bytes" > ${{ steps.iso-name.outputs.iso_name }}.sha256sum
+        sha256sum --tag "${{ steps.iso-name.outputs.iso_name }}" >> ${{ steps.iso-name.outputs.iso_name }}.sha256sum
         cat ${{ steps.iso-name.outputs.iso_name }}.sha256sum
         echo "SHA256SUM_FILENAME=${{ steps.iso-name.outputs.iso_name }}.sha256sum" >> $GITHUB_OUTPUT
 

--- a/deps.txt
+++ b/deps.txt
@@ -1,3 +1,4 @@
+aria2
 curl
 isomd5sum
 jq

--- a/isopatch.sh
+++ b/isopatch.sh
@@ -23,7 +23,7 @@ trap cleanup EXIT ERR
 main() {
     INPUT_ISO="$1"
     readonly INPUT_ISO
-    OUTPUT_ISO="${SCRIPT_DIR}/$(basename "${2:-output.iso}")"
+    OUTPUT_ISO="${SCRIPT_DIR}/${2:-output.iso}"
     readonly OUTPUT_ISO
 
     # ISO release version and architecture are embedded in .discinfo
@@ -178,6 +178,10 @@ EOF
     echo "Created ISO: ${OUTPUT_ISO}"
 
     sha256sum --tag "${OUTPUT_ISO}" | tee "${OUTPUT_ISO}.sha256sum"
+    if [ "${GITHUB_WORKSPACE}" != "" ]; then
+        mv "${OUTPUT_ISO}" "${GITHUB_WORKSPACE}"
+        mv "${OUTPUT_ISO}.sha256sum" "${GITHUB_WORKSPACE}"
+    fi
 }
 
 main "$@"

--- a/isopatch.sh
+++ b/isopatch.sh
@@ -178,7 +178,7 @@ EOF
     echo "Created ISO: ${OUTPUT_ISO}"
 
     sha256sum --tag "${OUTPUT_ISO}" | tee "${OUTPUT_ISO}.sha256sum"
-    if [ "${GITHUB_WORKSPACE}" != "" ]; then
+    if [ "${GITHUB_WORKSPACE:-}" != "" ]; then
         mv "${OUTPUT_ISO}" "${GITHUB_WORKSPACE}"
         mv "${OUTPUT_ISO}.sha256sum" "${GITHUB_WORKSPACE}"
     fi

--- a/isopatch.sh
+++ b/isopatch.sh
@@ -178,7 +178,7 @@ EOF
     echo "Created ISO: ${OUTPUT_ISO}"
 
     sha256sum --tag "${OUTPUT_ISO}" | tee "${OUTPUT_ISO}.sha256sum"
-    if [ "${GITHUB_WORKSPACE:-}" != "" ]; then
+    if [ "${GITHUB_WORKSPACE:-}" != "${SCRIPT_DIR}" ]; then
         mv "${OUTPUT_ISO}" "${GITHUB_WORKSPACE}"
         mv "${OUTPUT_ISO}.sha256sum" "${GITHUB_WORKSPACE}"
     fi

--- a/isopatch.sh
+++ b/isopatch.sh
@@ -177,7 +177,10 @@ EOF
     implantisomd5 "${OUTPUT_ISO}"
     echo "Created ISO: ${OUTPUT_ISO}"
 
-    sha256sum --tag "${OUTPUT_ISO}" | tee "${OUTPUT_ISO}.sha256sum"
+    {
+        stat -c "# ${OUTPUT_ISO} - size %s bytes" "${OUTPUT_ISO}"
+        sha256sum --tag "${OUTPUT_ISO}"
+    } | tee "${OUTPUT_ISO}.sha256sum"
     if [ "${GITHUB_WORKSPACE:-}" != "${SCRIPT_DIR}" ]; then
         mv "${OUTPUT_ISO}" "${GITHUB_WORKSPACE}"
         mv "${OUTPUT_ISO}.sha256sum" "${GITHUB_WORKSPACE}"


### PR DESCRIPTION
I was having issues with the output iso-path not being available from the consumer action so now I move stuff to GITHUB_WORKSPACE 

not sure if this is right tbh

