### PR TITLE
feat: add DE info to image menu

### DIFF
--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -3,9 +3,13 @@ ublue_variants:
     ks: /kickstart/ublue-os.ks
     flavors:
       - label: silverblue-main
+        info: GNOME
       - label: kinoite-main
+        info: KDE
       - label: vauxite-main
+        info: Xfce
       - label: sericea-main
+        info: Sway
       - label: lxqt-main
       - label: mate-main
       - label: base-main
@@ -18,9 +22,13 @@ ublue_variants:
         suffix: -470
     flavors:
       - label: silverblue-nvidia
+        info: GNOME
       - label: kinoite-nvidia
+        info: KDE
       - label: vauxite-nvidia
+        info: Xfce
       - label: sericea-nvidia
+        info: Sway
       - label: lxqt-nvidia
       - label: mate-nvidia
       - label: base-nvidia


### PR DESCRIPTION
Currently, when launching the ISO, images with upstream names (Silverblue, Kinoite, Vauxite and Sericea) do not communicate which DE they ship with. This may be confusing for end users that may not be familiar with the names of immutable Fedora distributions. I can foresee users checking out uBlue now that it's getting more press, attempting to switch from a traditional distribution with their DE of choice to uBlue, and not being quite sure which image to choose.

This PR resolves this by adding info fields into `boot_menu.yml` which adds the desktop environment these images ship with.