### PR TITLE
fix: use basename to strip file path of ISO file in sha256sum file

### DIFF
--- a/isopatch.sh
+++ b/isopatch.sh
@@ -197,7 +197,7 @@ EOF
 
     {
         stat -c "# ${OUTPUT_ISO} - size %s bytes" "${OUTPUT_ISO}"
-        sha256sum --tag "${OUTPUT_ISO}"
+        sha256sum --tag $(basename "${OUTPUT_ISO}")
     } | tee "${OUTPUT_ISO}.sha256sum"
     if [ "${GITHUB_WORKSPACE:-}" != "${SCRIPT_DIR}" ]; then
         mv "${OUTPUT_ISO}" "${GITHUB_WORKSPACE}"

--- a/isopatch.sh
+++ b/isopatch.sh
@@ -197,7 +197,7 @@ EOF
 
     {
         stat -c "# ${OUTPUT_ISO} - size %s bytes" "${OUTPUT_ISO}"
-        sha256sum --tag $(basename "${OUTPUT_ISO}")
+        sha256sum --tag "$(basename "${OUTPUT_ISO}")"
     } | tee "${OUTPUT_ISO}.sha256sum"
     if [ "${GITHUB_WORKSPACE:-}" != "${SCRIPT_DIR}" ]; then
         mv "${OUTPUT_ISO}" "${GITHUB_WORKSPACE}"


### PR DESCRIPTION
Fixes: https://github.com/ublue-os/main/issues/221

I think this should fix the path being included in the sha256sum files.

Needs testing.