### PR TITLE
grub.cfg: Use flavor_menu.label

### DIFF
--- a/installer/overlay/x86_64/EFI/BOOT/grub.cfg
+++ b/installer/overlay/x86_64/EFI/BOOT/grub.cfg
@@ -36,7 +36,7 @@ submenu 'Install {{ submenu.label }} -->' {
 				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
-			menuentry 'Install silverblue-main:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+			menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
 				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
@@ -51,7 +51,7 @@ submenu 'Install {{ submenu.label }} -->' {
 			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}
-		menuentry 'Install silverblue-main:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
 			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}


### PR DESCRIPTION
Use variable `flavor_menu.label` instead of hardcoded name `silverblue-main`.