### PR TITLE
feat: Add separate GRUB entries to verify installation media

### DIFF
--- a/installer/overlay/x86_64/EFI/BOOT/grub.cfg
+++ b/installer/overlay/x86_64/EFI/BOOT/grub.cfg
@@ -33,11 +33,11 @@ submenu 'Install {{ submenu.label }} -->' {
 {%- for flavor_menu in submenu.flavors %}
 		submenu 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) -->' {
 			menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }})' --class fedora --class gnu-linux --class gnu --class os {
-				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
+				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
 			menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
+				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
 		}
@@ -48,11 +48,11 @@ submenu 'Install {{ submenu.label }} -->' {
 {%- for flavor_menu in submenu.flavors %}
 	submenu 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} -->' {
 		menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %}' --class fedora --class gnu-linux --class gnu --class os {
-			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
+			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}
 		menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
+			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}
 	}

--- a/installer/overlay/x86_64/EFI/BOOT/grub.cfg
+++ b/installer/overlay/x86_64/EFI/BOOT/grub.cfg
@@ -40,6 +40,14 @@ submenu 'Install {{ submenu.label }} -->' {
 				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
+			menuentry 'Verify then install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }})' --class fedora --class gnu-linux --class gnu --class os {
+				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
+				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
+			}
+			menuentry 'Verify then install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
+				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
+			}
 		}
 {%- endfor %}
 	}
@@ -53,6 +61,14 @@ submenu 'Install {{ submenu.label }} -->' {
 		}
 		menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
 			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
+			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
+		}
+		menuentry 'Verify then install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %}' --class fedora --class gnu-linux --class gnu --class os {
+			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
+			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
+		}
+		menuentry 'Verify then install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}
 	}


### PR DESCRIPTION
I have found on both my laptop and desktop that rd.live.check can hang for an indeterminate amount of time, even in cases where the installation media is perfectly fine. This removes installation media verification from the main entries and creates two additional entries (one normal, one nomodeset) that contain the check for those that wish to use it