### PR TITLE
fix(deck): Move installer resolution override to grub.cfg

### DIFF
--- a/installer/kickstart/ublue-os-deck.ks
+++ b/installer/kickstart/ublue-os-deck.ks
@@ -4,7 +4,7 @@
 
 %include /tmp/ks-urls.txt
 
-bootloader --append="inst.resolution=1280x800 amd_pstate=active amd_iommu=off amdgpu.gttsize=8128 spi_amd.speed_dev=1 audit=0 initcall_blacklist=simpledrm_platform_driver_init rd.luks.options=discard"
+bootloader --append="amd_pstate=active amd_iommu=off amdgpu.gttsize=8128 spi_amd.speed_dev=1 audit=0 initcall_blacklist=simpledrm_platform_driver_init rd.luks.options=discard"
 
 %post --logfile=/root/ks-post.log --erroronfail --nochroot
 %end

--- a/installer/overlay/x86_64/EFI/BOOT/grub.cfg
+++ b/installer/overlay/x86_64/EFI/BOOT/grub.cfg
@@ -33,11 +33,11 @@ submenu 'Install {{ submenu.label }} -->' {
 {%- for flavor_menu in submenu.flavors %}
 		submenu 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) -->' {
 			menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }})' --class fedora --class gnu-linux --class gnu --class os {
-				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
+				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
 			menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
+				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
 		}
@@ -48,11 +48,11 @@ submenu 'Install {{ submenu.label }} -->' {
 {%- for flavor_menu in submenu.flavors %}
 	submenu 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} -->' {
 		menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %}' --class fedora --class gnu-linux --class gnu --class os {
-			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
+			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}
 		menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
+			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}
 	}


### PR DESCRIPTION
Kickstart is applied during installation instead of before so we need this in grub.cfg instead