### PR TITLE
fix(grub.cfg): Kill rd.live.check to avoid hangs

### DIFF
--- a/installer/overlay/x86_64/EFI/BOOT/grub.cfg
+++ b/installer/overlay/x86_64/EFI/BOOT/grub.cfg
@@ -33,11 +33,11 @@ submenu 'Install {{ submenu.label }} -->' {
 {%- for flavor_menu in submenu.flavors %}
 		submenu 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) -->' {
 			menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }})' --class fedora --class gnu-linux --class gnu --class os {
-				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
+				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
 			menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} ({{ subvariant.label }}) in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
+				linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}{% if subvariant.suffix is defined %}{{ subvariant.suffix }}{% endif %}
 				initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 			}
 		}
@@ -48,11 +48,11 @@ submenu 'Install {{ submenu.label }} -->' {
 {%- for flavor_menu in submenu.flavors %}
 	submenu 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} -->' {
 		menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %}' --class fedora --class gnu-linux --class gnu --class os {
-			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} rd.live.check quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
+			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}
 		menuentry 'Install {{ flavor_menu.label }}:{{ RELEASE }}{% if flavor_menu.info is defined %} ({{ flavor_menu.info }}){% endif %} in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset rd.live.check quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
+			linux{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ VOLUME_ID }} nomodeset quiet {% if "deck" in submenu.ks %}inst.resolution=1280x800 {% endif %}inst.ks=hd:LABEL={{ VOLUME_ID }}:{{ flavor_menu.ks | default(submenu.ks) }} imageurl=ghcr.io/{{ GITHUB_REPOSITORY_OWNER }}/{{ flavor_menu.label }}:{{ RELEASE }}
 			initrd{% if BOOT_TYPE == 'efi' %}efi{% endif %} /images/pxeboot/initrd.img
 		}
 	}


### PR DESCRIPTION
For whatever reason, rd.live.check leads to hangs for some system configurations during the installation process without any verbose output. Some users get left with nothing more than a black screen and cursor when this is enabled