### PR TITLE
fix: kickstart-file-path not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: 'releases'
   kickstart-file-path:
     description: 'Path to the kickstart file'
-    required: true
+    required: false
   cpu-arch:
     description: 'CPU architecture for installer'
     required: false


### PR DESCRIPTION
I noticed that my linter screams when I open the iso build action in the startingpoint template, because this file says `kickstart-file-path` is required, but it's not used in startingpoint.

Anyway, I'm assuming marking it as _not_ required is a better fix than putting it into kickstart template.