### PR TITLE
feat: Update to Fedora 39 and use latest tag

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -37,7 +37,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: fedora:38
+      image: fedora:39
       options: --privileged
     steps:
       - name: checkout to execute local action
@@ -47,7 +47,7 @@ jobs:
         id: selftest
         with:
           image-name: ublue-test
-          installer-major-version: 38
+          installer-major-version: 39
           installer-repo: releases
           boot-menu-path: boot_menu.yml
       - name: upload test result as artifact

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:39
 
 COPY ./deps.txt /tmp/deps.txt
 RUN dnf install \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example:
     needs: release-please
     if: needs.release-please.outputs.releases_created
     container: 
-      image: fedora:38
+      image: fedora:39
       options: --privileged
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ Example:
         with:
           image-name: nameoftheiso
           installer-repo: releases
-          installer-major-version: 38
+          installer-major-version: 39
       - name: install github CLI
         run: |
           sudo dnf install 'dnf-command(config-manager)' -y

--- a/generate-installer-media.sh
+++ b/generate-installer-media.sh
@@ -23,7 +23,10 @@ trap cleanup EXIT
 # ISO release version and architecture are embedded in .discinfo
 xorriso -indev "${INPUT_ISO}" -osirrox on -extract /.discinfo "${WORK_DIR}/.discinfo"
 
-readonly RELEASE="$(sed "2q;d" "${WORK_DIR}/.discinfo")"
+RELEASE="$(sed "2q;d" "${WORK_DIR}/.discinfo")"
+[[ "${RELEASE}" -eq "39" ]] && RELEASE="latest"
+readonly RELEASE
+
 readonly ARCH="$(sed "3q;d" "${WORK_DIR}/.discinfo")"
 
 readonly VOLUME_ID="$(xorriso -indev "${INPUT_ISO}" -pvd_info 2> /dev/null | grep "^Volume Id" | cut -d ":" -f2 | awk '{$1=$1};1')"

--- a/installer/kickstart/pre-install.sh
+++ b/installer/kickstart/pre-install.sh
@@ -12,7 +12,10 @@ done
 
 URL=$(echo "${URL:-${DEFAULT_URL}}" | tr "[:upper:]" "[:lower:]")
 
-readonly RELEASE="$(sed "2q;d" "/run/install/repo/.discinfo")"
+RELEASE="$(sed "2q;d" "/run/install/repo/.discinfo")"
+[[ "${RELEASE}" -eq "39" ]] && RELEASE="latest"
+readonly RELEASE
+
 readonly ARCH="$(sed "3q;d" "/run/install/repo/.discinfo")"
 
 cat << EOL > /tmp/ks-urls.txt

--- a/installer/kickstart/pre-install.sh
+++ b/installer/kickstart/pre-install.sh
@@ -2,7 +2,7 @@
 
 set -oue pipefail
 
-DEFAULT_URL="ghcr.io/ublue-os/silverblue-main:38"
+DEFAULT_URL="ghcr.io/ublue-os/silverblue-main:39"
 
 for ARG in `cat /proc/cmdline`; do
     if [[ "${ARG}" =~ ^imageurl= ]]; then

--- a/isopatch.sh
+++ b/isopatch.sh
@@ -46,7 +46,7 @@ main() {
     readonly ESP_IMG
 
     # Prepare overlay
-    patch_grub_cfg 
+    patch_grub_cfg
     generate_ks
     copy_secure_boot_keys
 

--- a/isopatch.sh
+++ b/isopatch.sh
@@ -36,6 +36,7 @@ main() {
     xorriso -indev "${INPUT_ISO}" -osirrox on -extract /.discinfo "${WORK_DIR}/.discinfo"
 
     RELEASE="$(sed "2q;d" "${WORK_DIR}/.discinfo")"
+    [[ "${RELEASE}" -eq "39" ]] && RELEASE="latest"
     readonly RELEASE
     ARCH="$(sed "3q;d" "${WORK_DIR}/.discinfo")"
     readonly ARCH


### PR DESCRIPTION
This updates isogenerator to Fedora 39 and uses the latest tag for the latest release instead of the Fedora version in the installation media